### PR TITLE
Remove hidden class to avoid double chapterText

### DIFF
--- a/src/en/readlightnovel/ReadLightNovelScraper.js
+++ b/src/en/readlightnovel/ReadLightNovelScraper.js
@@ -153,7 +153,7 @@ const chapterScraper = async (req, res) => {
         });
 
     $(".alert").remove();
-    $("#growfoodsmart").remove();
+    $(".hidden").remove();
 
     let chapterText = $(".desc").html();
     chapterText = htmlToText(chapterText).replace(/\n\nSponsored Content\n\n/g, "");


### PR DESCRIPTION
Today I noticed that ReadLightNovel added a new #hiddenchapter in all of their novels which will again output the chapterText twice like here. 

<img src="https://user-images.githubusercontent.com/63963181/117936876-fd02a100-b322-11eb-84a8-284615686b81.png" height="700" width="360">

The common thing between `#growsmartfood` in the fix #11 and the new addition from ReadLightNovel are that they are hidden class. So I removed the hidden class instead.